### PR TITLE
fix: improve color contrast for hero description text

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -147,7 +147,7 @@ body {
 
 .hero-description {
     font-size: clamp(1rem, 2.5vw, 1.25rem);
-    color: var(--text-muted);
+    color: #5A5A5A;
     margin-bottom: 48px;
     line-height: 1.7;
     max-width: 700px;


### PR DESCRIPTION
@ -0,0 +1,18 @@
# Fix: Hero Description Color Contrast

## 🐛 Issue
Hero description text fails WCAG 2 AA contrast requirements (4.33 ratio, needs 4.5:1)

## ✅ Fix
- Changed color from `#757575` to `#5A5A5A`
- Now meets WCAG 2 AA standards with 4.5:1+ contrast ratio

## 📁 Files Changed
- `public/styles.css`

## 🧪 Testing
- [x] Contrast ratio verified
- [x] Visual appearance maintained
- [x] Accessibility compliance achieved

Fixes accessibility issue for hero description element.