### PR TITLE
fix: remove gradient background from plan options for better contrast

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -520,7 +520,7 @@ body {
 }
 
 .plan-option {
-    background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+    background: #FFFFFF;
     border: 2px solid #dee2e6;
     border-radius: 12px;
     padding: 20px;


### PR DESCRIPTION
@ -0,0 +1,18 @@
# Fix: Plan Options Background Contrast

## 🐛 Issue
Plan option elements use gradient backgrounds causing accessibility tools to fail color contrast determination

## ✅ Fix
- Replaced `linear-gradient(135deg, #f8f9fa, #e9ecef)` with solid `#FFFFFF`
- Maintains visual appeal while fixing accessibility scanning

## 📁 Files Changed
- `public/styles.css`

## 🧪 Testing
- [x] Accessibility tools can now determine contrast
- [x] Visual design preserved
- [x] Login options remain functional

Fixes color contrast determination issues for MetaMask and Email login options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the background of plan option cards from a gradient to solid white.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->