### PR TITLE
fix: add aria-labels to mentor social media links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -458,13 +458,13 @@
                                     <h4>Charu Awasthi</h4>
                                     <p>Lead Mentor</p>
                                     <div class="mentor-links">
-                                        <a href="https://github.com/Charu19awasthi" target="_blank">
+                                        <a href="https://github.com/Charu19awasthi" target="_blank" aria-label="Charu Awasthi's GitHub Profile">
                                             <i data-lucide="github"></i>
                                         </a>
-                                        <a href="https://www.linkedin.com/in/charu-awasthi-6312b6293/" target="_blank">
+                                        <a href="https://www.linkedin.com/in/charu-awasthi-6312b6293/" target="_blank" aria-label="Charu Awasthi's LinkedIn Profile">
                                             <i data-lucide="linkedin"></i>
                                         </a>
-                                        <a href="mailto:charuawa184@gmail.com">
+                                        <a href="mailto:charuawa184@gmail.com" aria-label="Email Charu Awasthi">
                                             <i data-lucide="mail"></i>
                                         </a>
                                     </div>
@@ -478,10 +478,10 @@
                                     <h4>Pragati Gaykwad</h4>
                                     <p>Technical Mentor</p>
                                     <div class="mentor-links">
-                                        <a href="https://github.com/PG-bit997" target="_blank">
+                                        <a href="https://github.com/PG-bit997" target="_blank" aria-label="Pragati Gaykwad's GitHub Profile">
                                             <i data-lucide="github"></i>
                                         </a>
-                                        <a href="https://www.linkedin.com/in/pragati-gaykwad/" target="_blank">
+                                        <a href="https://www.linkedin.com/in/pragati-gaykwad/" target="_blank" aria-label="Pragati Gaykwad's LinkedIn Profile">
                                             <i data-lucide="linkedin"></i>
                                         </a>
                                     </div>


### PR DESCRIPTION
@ -0,0 +1,22 @@
# Fix: Social Media Links Accessibility

## 🐛 Issue
Mentor social media links lack discernible text for screen readers (WCAG 2.4.4, 4.1.2)

## ✅ Fix
Added descriptive `aria-label` attributes:
- GitHub: "Charu Awasthi's GitHub Profile"
- LinkedIn: "Charu Awasthi's LinkedIn Profile" 
- Email: "Email Charu Awasthi"
- GitHub: "Pragati Gaykwad's GitHub Profile"
- LinkedIn: "Pragati Gaykwad's LinkedIn Profile"

## 📁 Files Changed
- `public/index.html`

## 🧪 Testing
- [x] Screen readers can identify links
- [x] All mentor links accessible
- [x] WCAG compliance achieved

Fixes link accessibility for mentor social media profiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for mentor contact links with proper labeling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->