### PR TITLE
fix: add aria-labels to project and contact links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -404,9 +404,7 @@
                                 <i data-lucide="external-link"></i>
                                 <span>Live Demo</span>
                             </a>
-                            <a href="https://github.com/Gooichand/blockchain-evidence/blob/main/CONTRIBUTING.md"
-                                target="_blank" class="project-link">
-                            <a href="https://github.com/Gooichand/blockchain-evidence/blob/main/Contributing.md" target="_blank" class="project-link">
+                            <a href="https://github.com/Gooichand/blockchain-evidence/blob/main/Contributing.md" target="_blank" class="project-link" aria-label="View Contributing Guide on GitHub">
                                 <i data-lucide="book-open"></i>
                                 <span>Contributing Guide</span>
                             </a>
@@ -656,15 +654,13 @@
                         <h3>Phone Support</h3>
                         <p>+91 9390606393</p>
                     </div>
-                     <a href="https://github.com/Gooichand/blockchain-evidence" target="_blank" class="contact-item-link">
+                     <a href="https://github.com/Gooichand/blockchain-evidence" target="_blank" class="contact-item-link" aria-label="View GitHub Repository">
                     <div class="contact-item">
                         <div class="contact-icon">
                             <i data-lucide="github"></i>
                         </div>
                         <h3>GitHub</h3>
-                        <p><a href="https://github.com/Gooichand/blockchain-evidence" target="_blank">View
-                                Repository</a></p>
-                       <p>View Repository</p>
+                        <p>View Repository</p>
                     </div>
                     </a>
                     <div class="contact-item">


### PR DESCRIPTION
@ -0,0 +1,21 @@
# Fix: Project and Contact Links Accessibility

## 🐛 Issue
Project and contact links missing discernible text and have duplicate structures

## ✅ Fix
- Added `aria-label="View Contributing Guide on GitHub"` to contributing link
- Added `aria-label="View GitHub Repository"` to contact GitHub link
- Removed duplicate nested link structures
- Fixed malformed HTML in contact section

## 📁 Files Changed
- `public/index.html`

## 🧪 Testing
- [x] All links have proper labels
- [x] No duplicate link structures
- [x] Screen reader accessible
- [x] WCAG 2.4.4 & 4.1.2 compliant

Fixes accessibility issues for project and contact page links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Contributing Guide and GitHub Repository navigation links now feature enhanced accessibility improvements, making them more discoverable and easier for users to navigate.
  * Contributing Guide link structure has been consolidated and streamlined, removing redundant elements to provide improved clarity and user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->