### PR TITLE
Fix: Missing password visibility toggle in Login & Register forms

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -308,6 +308,30 @@ function setupModalClickOutside(modalId, closeFunction) {
   }
 }
 
+// Toggle password visibility
+function togglePasswordVisibility(inputId) {
+  const input = document.getElementById(inputId);
+  const toggleBtn = document.querySelector(`button[onclick="togglePasswordVisibility('${inputId}')"]`);
+
+  if (!input || !toggleBtn) return;
+
+  const icon = toggleBtn.querySelector('i');
+
+  if (input.type === 'password') {
+    input.type = 'text';
+    if (icon) {
+      icon.setAttribute('data-lucide', 'eye-off');
+      lucide.createIcons();
+    }
+  } else {
+    input.type = 'password';
+    if (icon) {
+      icon.setAttribute('data-lucide', 'eye');
+      lucide.createIcons();
+    }
+  }
+}
+
 // Wallet connection
 async function connectWallet() {
   console.log("Attempting to connect wallet...");

--- a/public/index.html
+++ b/public/index.html
@@ -650,8 +650,14 @@
                         <i data-lucide="lock"></i>
                         Password
                     </label>
-                    <input type="password" id="loginPassword" class="form-control" placeholder="Enter your password"
-                        required>
+                    <div class="password-input-wrapper">
+                        <input type="password" id="loginPassword" class="form-control" placeholder="Enter your password"
+                            required>
+                        <button type="button" class="password-toggle-btn"
+                            onclick="togglePasswordVisibility('loginPassword')" aria-label="Toggle password visibility">
+                            <i data-lucide="eye"></i>
+                        </button>
+                    </div>
                 </div>
                 <!-- Forgot Password Link -->
                 <div class="text-right mb-4" style="text-align: right; margin-bottom: 1rem;">
@@ -730,8 +736,14 @@
                         <i data-lucide="lock"></i>
                         Password
                     </label>
-                    <input type="password" id="regPassword" class="form-control" placeholder="Create a password"
-                        required>
+                    <div class="password-input-wrapper">
+                        <input type="password" id="regPassword" class="form-control" placeholder="Create a password"
+                            required>
+                        <button type="button" class="password-toggle-btn"
+                            onclick="togglePasswordVisibility('regPassword')" aria-label="Toggle password visibility">
+                            <i data-lucide="eye"></i>
+                        </button>
+                    </div>
                     <div id="regPasswordStrength" class="password-strength">
                         <div class="strength-meter">
                             <div class="strength-fill"></div>
@@ -744,8 +756,15 @@
                         <i data-lucide="lock"></i>
                         Confirm Password
                     </label>
-                    <input type="password" id="regConfirmPassword" class="form-control"
-                        placeholder="Confirm your password" required>
+                    <div class="password-input-wrapper">
+                        <input type="password" id="regConfirmPassword" class="form-control"
+                            placeholder="Confirm your password" required>
+                        <button type="button" class="password-toggle-btn"
+                            onclick="togglePasswordVisibility('regConfirmPassword')"
+                            aria-label="Toggle password visibility">
+                            <i data-lucide="eye"></i>
+                        </button>
+                    </div>
                 </div>
                 <div class="form-group">
                     <label for="regFullName">

--- a/public/styles.css
+++ b/public/styles.css
@@ -636,6 +636,42 @@ body {
     border-color: var(--primary-red-light);
 }
 
+/* Password Toggle Styles */
+.password-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.password-input-wrapper .form-control {
+    padding-right: 50px;
+}
+
+.password-toggle-btn {
+    position: absolute;
+    right: 12px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-secondary);
+    transition: all 0.2s ease;
+    border-radius: 6px;
+}
+
+.password-toggle-btn:hover {
+    color: var(--primary-red);
+    background: var(--primary-red-light);
+}
+
+.password-toggle-btn i {
+    width: 20px;
+    height: 20px;
+}
+
 .form-actions {
     text-align: center;
     margin-top: 30px;


### PR DESCRIPTION
## Summary
Adds a password visibility (eye) toggle to both Login and Create Account forms.

## Changes
- Added show/hide password toggle icon
- Ensured consistent behavior across authentication flow
- Improved usability and reduced input errors

## Related Issue
Closes #178

## Testing
- Tested email login with valid/invalid credentials
- Tested registration flow
- Verified toggle works correctly in both forms
<img width="923" height="820" alt="Screenshot 2026-02-08 012153" src="https://github.com/user-attachments/assets/204fef93-4fdd-4bbc-88a0-0257744bf5de" />
<img width="967" height="802" alt="Screenshot 2026-02-08 012130" src="https://github.com/user-attachments/assets/6f3cfbc6-28b3-4169-8280-b9d09b27b882" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggle to password input fields in login and registration modals. Users can now click the eye icon to show or hide their password for easier entry and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->