### PR TITLE
fix: add ARIA attributes to showAlert for screen reader accessibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -771,11 +771,23 @@ function showAlert(message, type = "info") {
 
   const alert = document.createElement("div");
   alert.className = `alert alert-${type}`;
+
+  // Add accessibility attributes for screen readers
+  // Use role="alert" for urgent messages (errors/warnings) - announces immediately
+  // Use role="status" for informational messages - announces politely
+  if (type === "error" || type === "warning") {
+    alert.setAttribute("role", "alert");
+    alert.setAttribute("aria-live", "assertive");
+  } else {
+    alert.setAttribute("role", "status");
+    alert.setAttribute("aria-live", "polite");
+  }
+
   alert.innerHTML = `
         <div style="display: flex; align-items: center; gap: 8px;">
             <i data-lucide="${getAlertIcon(
     type
-  )}" style="width: 16px; height: 16px;"></i>
+  )}" style="width: 16px; height: 16px;" aria-hidden="true"></i>
             <span>${message}</span>
         </div>
     `;


### PR DESCRIPTION
Fix: Make Toast Alerts Accessible to Screen Readers

Summary
@Gooichand, This PR addresses an accessibility issue where toast alerts created by showAlert() were not being announced by screen readers. Users relying on assistive technologies were not receiving audible feedback when alerts appeared on screen.

Problem
The showAlert() function creates a <div class="alert alert-[type]"> element that is dynamically appended to the DOM. However, without proper ARIA attributes, screen readers have no way of knowing they should announce this new content.

Steps to Reproduce:

Trigger an alert (e.g., attempt login with missing fields)
Use a screen reader to observe whether notification is announced
Note that alerts may not be announced

Solution
Added appropriate ARIA attributes to the alert element:

role="alert" + aria-live="assertive" for error and warning types — immediately interrupts screen reader to announce urgent messages role="status" + aria-live="polite" for success and info types — announces at the next natural pause without interrupting aria-hidden="true" on the decorative icon to prevent screen readers from announcing icon names

Changes Made
File: 
public/app.js
Function: 
showAlert()