### PR TITLE
Fix #223: Make email clickable

### DIFF
--- a/public/privacy.html
+++ b/public/privacy.html
@@ -98,7 +98,7 @@
 
                     <section>
                         <h2>5. Contact Information</h2>
-                        <p>For privacy-related questions: <strong>DGC2MHNE@proton.me</strong></p>
+                        <p>For privacy-related questions: <strong><a href="mailto:DGC2MHNE@proton.me">DGC2MHNE@proton.me</a></strong></p>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #223

Makes the privacy contact email clickable using a mailto link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the contact email address in the privacy policy clickable, enabling users to easily send emails directly from the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->