### PR TITLE
fix: remove duplicate logo in navbar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -104,12 +104,8 @@
     <header class="header-nav">
         <div class="navbar-container">
             <div class="nav-brand">
-
-                <img src="logo-32x32.png" alt="Logo" class="brand-logo">
-
- 
-                       <img src="logo-32x32.png" alt="Logo" class="brand-logo" style="height: 44px; width: 44px;">
-  </div>
+                <img src="logo-32x32.png" alt="EVID-DGC Logo" class="brand-logo">
+            </div>
             <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation menu">
                 <i data-lucide="menu" class="hamburger-icon"></i>
             </button>


### PR DESCRIPTION
Summary
Fixes the duplicate logo display issue in the dashboard navbar.

Changes Made
- Removed duplicate `<img>` tag for brand-logo in navigation header
- Improved alt text from "Logo" to "EVID-DGC Logo" for better accessibility
- Cleaned up extra whitespace and formatting
 
 Testing Done
- ✅ Tested locally - navbar now shows single logo
- ✅ Verified no visual regression
- ✅ Checked accessibility (improved alt text)

Checklist
- [x] Code follows project coding standards
- [x] Changes tested locally
- [x] Commit message follows conventional format
- [x] No breaking changes introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the header logo markup by removing duplicate image references and updating the logo alt text to "EVID-DGC Logo"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->