### PR TITLE
Fix privilege escalation vulnerability in EvidenceStorage.sol

### DIFF
--- a/contracts/EvidenceStorage.sol
+++ b/contracts/EvidenceStorage.sol
@@ -67,6 +67,7 @@ contract EvidenceStorage {
     
     function authorizeUser(address _user, string memory _role) public {
         require(authorizedUsers[msg.sender], "Not authorized");
+        require(keccak256(abi.encodePacked(userRoles[msg.sender])) == keccak256(abi.encodePacked("admin")), "Only admin can authorize");
         authorizedUsers[_user] = true;
         userRoles[_user] = _role;
     }


### PR DESCRIPTION
issue:---#255

**Description:**

This Pull Request addresses a security vulnerability where authorized users could grant admin privileges to others without having the admin role themselves.

**Changes:**

- 
- Modified the authorizeUser function in EvidenceStorage.sol.
- Added a requirement check to verify that the caller (msg.sender) has the "admin" role.
- The function now reverts with the error "Only admin can authorize" if a non-admin attempts to authorize a user.
- This ensures strict role-based access control for user authorization.

**Verification:**

- Reviewed the Solidity code to ensure the added require statement correctly compares the caller's role string with "admin".
- Confirmed that the fix prevents unauthorized privilege escalation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User authorization is now restricted to admin-level access only, strengthening access control permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->